### PR TITLE
OTB_DEBUG enable/disable at single source code level

### DIFF
--- a/include/otb.h
+++ b/include/otb.h
@@ -27,8 +27,12 @@
 
 #define USE_US_TIMER
 
-// #define OTB_DEBUG 1
 // #define OTB_ARDUINO 1
+
+// To disable DEBUG in a single source file
+// add #define OTB_DEBUG_DISABLE
+// before #include "otb.h"
+#define OTB_DEBUG 0     // 0 = disabled, 1 = enabled
 
 #ifdef OTB_ARDUINO
 #include <Arduino.h>

--- a/include/otb_macros.h
+++ b/include/otb_macros.h
@@ -34,13 +34,18 @@
                                               ##__VA_ARGS__)
 #endif
 
-#define INFO(...)  LOG(FALSE, __VA_ARGS__);
-#define WARN(...)  LOG(FALSE, __VA_ARGS__);
-#define ERROR(...)  LOG(TRUE, __VA_ARGS__);
+#define INFO(...)  LOG(FALSE, __VA_ARGS__)
+#define WARN(...)  LOG(FALSE, __VA_ARGS__)
+#define ERROR(...)  LOG(TRUE, __VA_ARGS__)
+
+#ifdef OTB_DEBUG_DISABLE
+#undef OTB_DEBUG
+#define OTB_DEBUG 0
+#endif
 
 #ifndef ESPUT
-#ifdef OTB_DEBUG
-  #define DEBUG(...)  LOG(FALSE, __VA_ARGS__);
+#if (OTB_DEBUG > 0)
+  #define DEBUG(...)  LOG(FALSE, __VA_ARGS__)
 #else // OTB_DEBUG
   #define DEBUG(...)
 #endif // OTB_DEBUG

--- a/lib/mqtt/mqtt.c
+++ b/lib/mqtt/mqtt.c
@@ -50,6 +50,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 #define MQTT_TASK_PRIO        		0

--- a/lib/mqtt/mqtt_msg.c
+++ b/lib/mqtt/mqtt_msg.c
@@ -54,6 +54,7 @@
 #include <Arduino.h>
 #endif
 #include <string.h>
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include "mqtt_msg.h"
 #include "mqtt_user_config.h"

--- a/src/otb_cmd.c
+++ b/src/otb_cmd.c
@@ -20,6 +20,7 @@
  */
 
 #define OTB_CMD_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include <stdarg.h>
 

--- a/src/otb_conf.c
+++ b/src/otb_conf.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_CONF_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_conf_init(void)

--- a/src/otb_ds18b20.c
+++ b/src/otb_ds18b20.c
@@ -34,6 +34,7 @@
  */
 
 #define OTB_DS18B20_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_ds18b20_initialize(uint8_t bus)

--- a/src/otb_flash.c
+++ b/src/otb_flash.c
@@ -19,5 +19,6 @@
 
 #define OTB_FLASH_C
 #define OTB_FLASH_INC_FUNCS
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 

--- a/src/otb_gpio.c
+++ b/src/otb_gpio.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_GPIO_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 uint8_t otb_gpio_pin_io_status[OTB_GPIO_ESP_GPIO_PINS];
@@ -438,7 +439,7 @@ bool ICACHE_FLASH_ATTR otb_gpio_set(int pin, int value, bool override_reserved)
   bool rc = FALSE;
   bool special;
   uint8 input;
-  char *error_text
+  char *error_text;
   
   DEBUG("GPIO: otb_gpio_set entry");
 

--- a/src/otb_httpd.c
+++ b/src/otb_httpd.c
@@ -20,6 +20,7 @@
  */
 
 #define OTB_HTTPD_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_httpd_start(void)

--- a/src/otb_i2c.c
+++ b/src/otb_i2c.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_I2C_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include "brzo_i2c.h"
 
@@ -1970,7 +1971,7 @@ bool ICACHE_FLASH_ATTR otb_i2c_write_one_reg(uint8_t addr, uint8_t reg, uint8_t 
 
   DEBUG("I2C: otb_i2c_write_one_reg entry");
   
-  rc = otb_i2c_write_reg_seq(addr, reg, 1, &val)
+  rc = otb_i2c_write_reg_seq(addr, reg, 1, &val);
   
   DEBUG("I2C: otb_i2c_write_one_reg exit");
   

--- a/src/otb_i2c_24xxyy.c
+++ b/src/otb_i2c_24xxyy.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_I2C_24XXYY_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include "brzo_i2c.h"
 
@@ -41,7 +42,7 @@ void ICACHE_FLASH_ATTR otb_i2c_24xxyy_test_timerfunc(void)
     }
     else
     {
-      INFO("24XXYY: Read byte 0x%02x", buf[0])
+      INFO("24XXYY: Read byte 0x%02x", buf[0]);
     }
     
     // Now toggle back

--- a/src/otb_i2c_mcp23017.c
+++ b/src/otb_i2c_mcp23017.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_I2C_MCP23017_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_i2c_mcp23017_test_timerfunc(void)

--- a/src/otb_i2c_pca9685.c
+++ b/src/otb_i2c_pca9685.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_I2C_PCA9685_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include "brzo_i2c.h"
 

--- a/src/otb_i2c_pcf8574.c
+++ b/src/otb_i2c_pcf8574.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_I2C_PCF8574_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_i2c_pcf8574_test_timerfunc(void)

--- a/src/otb_led.c
+++ b/src/otb_led.c
@@ -19,6 +19,7 @@
  */
 
 #define OTB_LED_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 bool ICACHE_FLASH_ATTR otb_led_test(unsigned char *name, bool repeat, unsigned char **error_text)

--- a/src/otb_main.c
+++ b/src/otb_main.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_MAIN_C
+// #define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void configModeCallback();

--- a/src/otb_mqtt.c
+++ b/src/otb_mqtt.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_MQTT_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_mqtt_publish(MQTT_Client *mqtt_client,

--- a/src/otb_rboot.c
+++ b/src/otb_rboot.c
@@ -17,6 +17,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 volatile rboot_ota otb_rboot_ota;

--- a/src/otb_recovery.c
+++ b/src/otb_recovery.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_RECOVERY_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR user_init(void)

--- a/src/otb_relay.c
+++ b/src/otb_relay.c
@@ -20,6 +20,7 @@
  */
 
 #define OTB_RELAY_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 int8_t otb_relay_id;

--- a/src/otb_util.c
+++ b/src/otb_util.c
@@ -18,6 +18,7 @@
  */
 
 #define OTB_UTIL_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 #include <stdarg.h>
 #include <limits.h>

--- a/src/otb_wifi.c
+++ b/src/otb_wifi.c
@@ -20,6 +20,7 @@
  */
 
 #define OTB_WIFI_C
+#define OTB_DEBUG_DISABLE
 #include "otb.h"
 
 void ICACHE_FLASH_ATTR otb_wifi_init(void)


### PR DESCRIPTION
Enabling `OTB_DEBUG` the .bss segment overflowed because of the great amount of strings added by `DEBUG()` calls.
By adding `#define OTB_DEBUG_DISABLE` before `#include "otb.h"` it is possible to enable/disable DEBUG output for each source file and satisfy .bss size constraints.